### PR TITLE
Fix Vulnerability in BotzinhosActionView

### DIFF
--- a/base/templates/base/_botzinhos_action_button.html
+++ b/base/templates/base/_botzinhos_action_button.html
@@ -1,0 +1,1 @@
+<form method="post" action="{% url "base:botzinhos-actions" bot.pk action %}">{% csrf_token %}<input class="btn {{ css_classes }}" type="submit" value="{{ text }}"></form>

--- a/base/templates/base/botzinhos_detail.html
+++ b/base/templates/base/botzinhos_detail.html
@@ -56,16 +56,16 @@
 			</li>
 			<li>
 				{% if not bot.price_buying %}
-				<a class="btn btn-success" href="{% url "base:botzinhos-actions" bot.pk "buy" %}">Force BUY</a>
+				{% bot_action_button "buy" "Force BUY" "btn-success" %}
 				{% else %}
-				<a class="btn btn-danger" href="{% url "base:botzinhos-actions" bot.pk "sell" %}">Force SELL</a>
+				{% bot_action_button "sell" "Force SELL" "btn-danger" %}
 				{% endif %}
 			</li>
 			<li>
 				{% if bot.status > bot.Status.INACTIVE %}
-				<a class="btn btn-dark" href="{% url "base:botzinhos-actions" bot.pk "off" %}">Turn OFF</a>
+				{% bot_action_button "off" "Turn OFF" "btn-dark" %}
 				{% else %}
-				<a class="btn btn-primary" href="{% url "base:botzinhos-actions" bot.pk "on" %}">Turn ON</a>
+				{% bot_action_button "on" "Turn ON" "btn-primary" %}
 				{% endif %}
 			</li>
 		</ul>

--- a/base/templatetags/symbols.py
+++ b/base/templatetags/symbols.py
@@ -66,3 +66,15 @@ def get(value, key):
     if not value:  # pragma: no cover
         return ""
     return value.get(key, "")
+
+
+@register.inclusion_tag(
+    "base/_botzinhos_action_button.html", takes_context=True
+)
+def bot_action_button(context, action, text, css_classes):
+    return {
+        "bot": context["bot"],
+        "action": action,
+        "text": text,
+        "css_classes": css_classes,
+    }

--- a/base/tests.py
+++ b/base/tests.py
@@ -226,7 +226,7 @@ class TestViews(TestCase):
                 "action": "start",
             },
         )
-        response = self.client.get(url, follow=True)
+        response = self.client.post(url, follow=True)
         self.assertEqual(response.status_code, 404)
         url = reverse(
             "base:botzinhos-actions",
@@ -235,7 +235,7 @@ class TestViews(TestCase):
                 "action": "on",
             },
         )
-        response = self.client.get(url, follow=True)
+        response = self.client.post(url, follow=True)
         self.assertEqual(response.status_code, 200)
         with mock.patch("base.models.TraderoBot.on") as bot_on_mock:
             bot_on_mock.side_effect = Exception("New Exception")
@@ -246,7 +246,7 @@ class TestViews(TestCase):
                     "action": "on",
                 },
             )
-            response = self.client.get(url, follow=True)
+            response = self.client.post(url, follow=True)
             self.assertEqual(response.status_code, 200)
             self.assertIn(b"ERROR at", response.content)
 

--- a/base/views.py
+++ b/base/views.py
@@ -168,6 +168,7 @@ class BotzinhosActionsView(OwnerMixin, LoginRequiredMixin, RedirectView):
     """
 
     permanent = False
+    http_method_names = ["post"]
     #: Available Actions
     ACTIONS = ["buy", "sell", "on", "off"]
 
@@ -177,9 +178,6 @@ class BotzinhosActionsView(OwnerMixin, LoginRequiredMixin, RedirectView):
     def get_object(self):
         self.object = get_object_or_404(TraderoBot, pk=self.pk)
         return self.object
-
-    def get(self, *args, **kwargs):
-        return super().get(*args, **kwargs)
 
     def run_action(self, action):
         try:


### PR DESCRIPTION
- Use `post` instead of `get` to have CSRF protection on the view